### PR TITLE
exclude inactive menu item for other roles

### DIFF
--- a/Resources/menu/menuhandles.yml
+++ b/Resources/menu/menuhandles.yml
@@ -2,3 +2,4 @@ indexer:
     parent: admin
     handle: indexer
     resources: [debug]
+    roles: [ROLE_SUPER_ADMIN]


### PR DESCRIPTION
Moin,
ist nur eine Zeile. Blendet diesen defekten Menüpunkt für andere aus.
Eigentlich ist es kein fix ^^